### PR TITLE
Fixed TestRail exception for uploading attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ TestLogger logger = new TestLogger();
 | `String captureScreen()`         | Returning the file path of the screenshot              |
 
 ## Changelog
+*4.4.1*
+- **[Bug Fix]**
+  - Fixed TestRail attachment upload exception
+
 *4.4.0*
 - **[Bug Fix]**
   - Fixed NullpointerException when no TestRail test cases matched if TESTRAIL_INCLUDE_ALL_AUTOMATED_TEST_CASES=false

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.scmp-contributor</groupId>
 	<artifactId>WebTestFramework</artifactId>
-	<version>4.4.0</version>
+	<version>4.4.1</version>
 	<packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/scmp/framework/testrail/TestRailManager.java
+++ b/src/main/java/com/scmp/framework/testrail/TestRailManager.java
@@ -393,7 +393,7 @@ public class TestRailManager {
 		data.put(CustomQuery, "");
 
 		File file = new File(imagePath);
-		RequestBody requestFile = RequestBody.create(file, MediaType.parse("multipart/form-data"));
+		RequestBody requestFile = RequestBody.create(MediaType.parse("multipart/form-data"), file);
 		MultipartBody.Part imageToUpload = MultipartBody.Part.createFormData("attachment", file.getName(), requestFile);
 
 		retrofit2.Response<Attachment> response = service.addAttachment(data, imageToUpload).execute();


### PR DESCRIPTION
```
RequestBody.create(file, MediaType.parse("multipart/form-data"));
```
the new implementation throws no such method exception during runtime, rollback to 
```
RequestBody.create(MediaType.parse("multipart/form-data"), file);
```
