### PR TITLE
fix older chrome version headless mode (<96 no headless mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ URL=<your testing url> INCLUDE_GROUPS=<your runtime include groups> mvn clean te
 BROWSER_TYPE=random
 # Selenium hub in docker server
 HOST_URL=http://localhost:4444/wd/hub
+# REMOTE_DRIVER_VERSION: version of the browser driver in selenium hub 
+# resolving headless mode issue for different browser versions
+REMOTE_DRIVER_VERSION=94
 
 ####################### FRAMEWORK ###########################################
 FRAMEWORK=testng
@@ -137,6 +140,10 @@ TestLogger logger = new TestLogger();
 | `String captureScreen()`         | Returning the file path of the screenshot              |
 
 ## Changelog
+*4.4.2*
+- **[Bug Fix]**
+  - Fixed Headless mode issue for Chrome in older versions
+  
 *4.4.1*
 - **[Bug Fix]**
   - Fixed TestRail attachment upload exception

--- a/config.properties
+++ b/config.properties
@@ -7,6 +7,8 @@
 BROWSER_TYPE=chrome
 # Selenium hub in docker server
 HOST_URL=http://localhost:4444/wd/hub
+# REMOTE_DRIVER_VERSION: version of the browser driver in selenium hub
+# resolving headless mode issue for different browser versions
 REMOTE_DRIVER_VERSION=94
 GLOBAL_CHROME_OPTIONS=--disable-notifications,--incognito
 PRELOAD_LOCAL_STORAGE_DATA=true

--- a/config.properties
+++ b/config.properties
@@ -7,6 +7,7 @@
 BROWSER_TYPE=chrome
 # Selenium hub in docker server
 HOST_URL=http://localhost:4444/wd/hub
+REMOTE_DRIVER_VERSION=94
 GLOBAL_CHROME_OPTIONS=--disable-notifications,--incognito
 PRELOAD_LOCAL_STORAGE_DATA=true
 LOCAL_STORAGE_DATA_PATH=data/configs/localstorage.properties

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.scmp-contributor</groupId>
 	<artifactId>WebTestFramework</artifactId>
-	<version>4.4.1</version>
+	<version>4.4.2</version>
 	<packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
+++ b/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
@@ -36,6 +36,9 @@ public class FrameworkConfigs {
 	@Value("${HOST_URL:#{''}}")
 	private String hostUrl;
 
+	@Value("${REMOTE_DRIVER_VERSION:#{''}}")
+	private int remoteDriverVersion;
+
 	@Value("${GLOBAL_CHROME_OPTIONS::#{''}}")
 	private String globalChromeOptions;
 

--- a/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
+++ b/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
@@ -36,7 +36,7 @@ public class FrameworkConfigs {
 	@Value("${HOST_URL:#{''}}")
 	private String hostUrl;
 
-	@Value("${REMOTE_DRIVER_VERSION:#{''}}")
+	@Value("${REMOTE_DRIVER_VERSION:#{0}}")
 	private int remoteDriverVersion;
 
 	@Value("${GLOBAL_CHROME_OPTIONS::#{''}}")

--- a/src/main/java/com/scmp/framework/executor/TestExecutor.java
+++ b/src/main/java/com/scmp/framework/executor/TestExecutor.java
@@ -59,19 +59,28 @@ public class TestExecutor {
 		}
 
 		System.setProperty(WDM_CACHE_PATH, context.getFrameworkConfigs().getDriverHome());
-		setupWebDriver(WebDriverManager.chromedriver(), CHROME_DRIVER_PATH);
-		setupWebDriver(WebDriverManager.firefoxdriver(), FIREFOX_DRIVER_PATH);
+		setupWebDriver(WebDriverManager.chromedriver(), CHROME_DRIVER_PATH, CHROME_DRIVER_VERSION);
+		setupWebDriver(WebDriverManager.firefoxdriver(), FIREFOX_DRIVER_PATH, FIREFOX_DRIVER_VERSION);
 	}
 
 	/**
 	 * Setup WebDriver and set global variable
 	 *
-	 * @param manager       WebDriverManager instance
-	 * @param driverPathKey Key for the driver path
+	 * @param manager       	WebDriverManager instance
+	 * @param driverPathKey 	Key for the driver path
+	 * @param driverVersionKey 	Key for the driver version
 	 */
-	private void setupWebDriver(@NotNull WebDriverManager manager, String driverPathKey) {
+	private void setupWebDriver(@NotNull WebDriverManager manager, String driverPathKey, String driverVersionKey) {
 		manager.setup();
-		context.setGlobalVariables(driverPathKey, manager.getDownloadedDriverPath());
+		String driverPath = manager.getDownloadedDriverPath();
+		String driverVersion = manager.getDownloadedDriverVersion();
+
+		// Set global variables for driver path and version
+		context.setGlobalVariables(driverPathKey, driverPath);
+		context.setGlobalVariables(driverVersionKey, driverVersion);
+
+		// Log both driver path and version in a consolidated message
+		frameworkLogger.info("WebDriver downloaded - Path: {}, Version: {}", driverPath, driverVersion);
 	}
 
 	/**

--- a/src/main/java/com/scmp/framework/utils/Constants.java
+++ b/src/main/java/com/scmp/framework/utils/Constants.java
@@ -19,6 +19,10 @@ public class Constants {
 	public static final String CHROME_DRIVER_PATH = "CHROME_DRIVER_PATH";
 	public static final String FIREFOX_DRIVER_PATH = "FIREFOX_DRIVER_PATH";
 
+	// WebDriver Version
+	public static final String CHROME_DRIVER_VERSION = "CHROME_DRIVER_VERSION";
+	public static final String FIREFOX_DRIVER_VERSION = "FIREFOX_DRIVER_VERSION";
+
 	// Keys for Global Variables
 	public static final String TEST_INFO_OBJECT = "TEST_INFO_OBJECT";
 	public static final String TEST_RUN_OBJECT = "TEST_RUN_OBJECT";


### PR DESCRIPTION
headless=new is recognised as invalid argument in older chrome version
- added config for remove chrome version
- load local driver version if executed locally
- added handling for different chrome version
- chrome version < 96 will not have headless mode 