### PR TITLE
Log consecutive failed cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ FEATURE_DESCRIPTION=
 DRIVER_HOME=drivers
 # With local execution mode(debug mode) ON, browser will be launched locally using driver in DRIVER_HOME
 LOCAL_EXECUTION=ON
+
+######################## FAILED_TESTCASE_NOTIFICATION ########################
+# NOTIFICATION_SEND_FAILED_CASE => Whether send fail case notification or not
+NOTIFICATION_SEND_FAILED_CASE=false
+# NOTIFICATION_FAILED_CASE_TESTRUN_PATTERN.regexp => Regex to search failed case for test run
+NOTIFICATION_FAILED_CASE_TESTRUN_PATTERN.regexp=Automated Test Run \d{1,2}/\d{1,2}/\d{4} master
+# NOTIFICATION_TESTRUN_COUNT => Number of test run to search for failed case
+NOTIFICATION_TESTRUN_COUNT=3
+# NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS => Filter test run within day period
+NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS=10
+# NOTIFICATION_FAILED_CASE_EXCLUDE_LIST => Exclude test case id from notification
+NOTIFICATION_FAILED_CASE_EXCLUDE_LIST=1701,1778,1779,1780,1781,1782,1783,1714,1701,1923,1797,1927,1800
 ```
 
 ### Useful Annotations

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ NOTIFICATION_TESTRUN_COUNT=3
 # NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS => Filter test run within day period (default 3 days)
 NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS=3
 # NOTIFICATION_FAILED_CASE_EXCLUDE_LIST => Exclude test case id from notification (The case id should be the Cxxxx in the testrun, only need the number and list cases separated by comma)
-NOTIFICATION_FAILED_CASE_EXCLUDE_LIST=1701,1778,1779,1780,1781,1782,1783,1714,1701,1923,1797,1927,1800
+NOTIFICATION_FAILED_CASE_EXCLUDE_LIST=
 ```
 
 ### Useful Annotations

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ TestLogger logger = new TestLogger();
 | `String captureScreen()`         | Returning the file path of the screenshot              |
 
 ## Changelog
+*4.4.3*
+- **[Enhancement]**
+  - Add logic to filter and show consecutive fail Testrail test case
+  
 *4.4.2*
 - **[Bug Fix]**
   - Fixed Headless mode issue for Chrome in older versions

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ LOCAL_EXECUTION=ON
 NOTIFICATION_SEND_FAILED_CASE=false
 # NOTIFICATION_FAILED_CASE_TESTRUN_PATTERN.regexp => Regex to search failed case for test run
 NOTIFICATION_FAILED_CASE_TESTRUN_PATTERN.regexp=Automated Test Run \d{1,2}/\d{1,2}/\d{4} master
-# NOTIFICATION_TESTRUN_COUNT => Number of test run to search for failed case
+# NOTIFICATION_TESTRUN_COUNT => Number of test run to search for failed case (default 3 test runs)
 NOTIFICATION_TESTRUN_COUNT=3
-# NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS => Filter test run within day period
-NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS=10
-# NOTIFICATION_FAILED_CASE_EXCLUDE_LIST => Exclude test case id from notification
+# NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS => Filter test run within day period (default 3 days)
+NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS=3
+# NOTIFICATION_FAILED_CASE_EXCLUDE_LIST => Exclude test case id from notification (The case id should be the Cxxxx in the testrun, only need the number and list cases separated by comma)
 NOTIFICATION_FAILED_CASE_EXCLUDE_LIST=1701,1778,1779,1780,1781,1782,1783,1714,1701,1923,1797,1927,1800
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ NOTIFICATION_TESTRUN_COUNT=3
 NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS=3
 # NOTIFICATION_FAILED_CASE_EXCLUDE_LIST => Exclude test case id from notification (The case id should be the Cxxxx in the testrun, only need the number and list cases separated by comma)
 NOTIFICATION_FAILED_CASE_EXCLUDE_LIST=
+# NOTIFICATION_FAILED_CASE_SLACK_USERID => Slack user id to send notification, can be found on slack personal profile, start with "U"
+NOTIFICATION_FAILED_CASE_SLACK_USERID=
+# NOTIFICATION_SLACK_WEBHOOK => Slack webhook to send notification
+NOTIFICATION_SLACK_WEBHOOK=
 ```
 
 ### Useful Annotations
@@ -154,7 +158,7 @@ TestLogger logger = new TestLogger();
 ## Changelog
 *4.4.3*
 - **[Enhancement]**
-  - Add logic to filter and show consecutive fail Testrail test case
+  - Add logic to filter and show consecutive fail Testrail test case and send in slack channel
   
 *4.4.2*
 - **[Bug Fix]**

--- a/pom.xml
+++ b/pom.xml
@@ -167,11 +167,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp</artifactId>
-			<version>4.12.0</version>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>4.12.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.scmp-contributor</groupId>
 	<artifactId>WebTestFramework</artifactId>
-	<version>4.4.2</version>
+	<version>4.4.3</version>
 	<packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
+++ b/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
@@ -129,7 +129,7 @@ public class FrameworkConfigs {
 	@Value("${NOTIFICATION_TESTRUN_COUNT:3}")
 	private int failedCaseNotificationCount;
 
-	@Value("${NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS:10}")
+	@Value("${NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS:3}")
 	private int failedCaseTestRunWithinDays;
 
 	@Value("${NOTIFICATION_FAILED_CASE_EXCLUDE_LIST:#{''}}")

--- a/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
+++ b/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
@@ -119,4 +119,19 @@ public class FrameworkConfigs {
 
 	@Value("${EXTENT_XML_PATH:#{null}}")
 	private String extentXMLPath;
+
+	@Value("${NOTIFICATION_SEND_FAILED_CASE:#{false}}")
+	private boolean sendFailedCaseNotification;
+
+	@Value("${NOTIFICATION_FAILED_CASE_TESTRUN_PATTERN.regexp:#{''}}")
+	private String failedCaseTestRunNotificationPattern;
+
+	@Value("${NOTIFICATION_TESTRUN_COUNT:3}")
+	private int failedCaseNotificationCount;
+
+	@Value("${NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS:10}")
+	private int failedCaseTestRunWithinDays;
+
+	@Value("${NOTIFICATION_FAILED_CASE_EXCLUDE_LIST:#{''}}")
+	private String failedCaseExcludeList;
 }

--- a/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
+++ b/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
@@ -135,8 +135,8 @@ public class FrameworkConfigs {
 	@Value("${NOTIFICATION_FAILED_CASE_EXCLUDE_LIST:#{''}}")
 	private String failedCaseExcludeList;
 
-	@Value("${NOTIFICATION_FAILED_CASE_SLACK_USERID:#{''}}")
-	private String failedCaseNotificationSlackUserId;
+	@Value("${NOTIFICATION_FAILED_CASE_SLACK_USERID:${GITLAB_USER_LOGIN:}}")
+	private String failedCaseNotificationUserId;
 
 	@Value("${NOTIFICATION_FAILED_CASE_SLACK_WEBHOOK:#{''}}")
 	private String failedCaseNotificationSlackWebhook;

--- a/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
+++ b/src/main/java/com/scmp/framework/context/FrameworkConfigs.java
@@ -134,4 +134,10 @@ public class FrameworkConfigs {
 
 	@Value("${NOTIFICATION_FAILED_CASE_EXCLUDE_LIST:#{''}}")
 	private String failedCaseExcludeList;
+
+	@Value("${NOTIFICATION_FAILED_CASE_SLACK_USERID:#{''}}")
+	private String failedCaseNotificationSlackUserId;
+
+	@Value("${NOTIFICATION_FAILED_CASE_SLACK_WEBHOOK:#{''}}")
+	private String failedCaseNotificationSlackWebhook;
 }

--- a/src/main/java/com/scmp/framework/services/SlackbotService.java
+++ b/src/main/java/com/scmp/framework/services/SlackbotService.java
@@ -1,15 +1,11 @@
-package com.scmp.framework.slackbot;
+package com.scmp.framework.services;
 
 import com.scmp.framework.context.ApplicationContextProvider;
-import com.scmp.framework.context.FrameworkConfigs;
-import com.scmp.framework.context.RunTimeContext;
 import okhttp3.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
 
 @Component
 public class SlackbotService {

--- a/src/main/java/com/scmp/framework/slackbot/SlackbotService.java
+++ b/src/main/java/com/scmp/framework/slackbot/SlackbotService.java
@@ -1,0 +1,53 @@
+package com.scmp.framework.slackbot;
+
+import com.scmp.framework.context.ApplicationContextProvider;
+import com.scmp.framework.context.FrameworkConfigs;
+import com.scmp.framework.context.RunTimeContext;
+import okhttp3.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class SlackbotService {
+
+    private static final Logger frameworkLogger = LoggerFactory.getLogger(SlackbotService.class);
+    private final OkHttpClient client;
+
+    public SlackbotService() {
+        ApplicationContext context = ApplicationContextProvider.getApplicationContext();
+        client = new OkHttpClient();
+    }
+
+    /**
+     * This function send a message to Slack channel
+     *
+     * @param webhookUrl channel id to send message
+     * @param message    message to be sent
+     * @return true if message is sent successfully, false otherwise
+     */
+    public boolean sendMessageToSlackChannel(String webhookUrl, String message) {
+
+        try {
+
+            RequestBody requestBody = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), "{\"text\":\"" + message + "\"}");
+            Request request = new Request.Builder().url(webhookUrl).post(requestBody).build();
+            Response response = client.newCall(request).execute();
+
+            if (response.isSuccessful()) {
+                frameworkLogger.info("Message sent to Slack channel successfully");
+                return true;
+            } else {
+                frameworkLogger.info("Message sent to Slack channel failed: " + response.code());
+                return false;
+            }
+
+        } catch (Exception e) {
+            frameworkLogger.info("Message sent to Slack channel failed: " + e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/scmp/framework/testng/listeners/SuiteListener.java
+++ b/src/main/java/com/scmp/framework/testng/listeners/SuiteListener.java
@@ -21,7 +21,6 @@ import org.testng.ISuiteListener;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -277,7 +276,7 @@ public class SuiteListener implements ISuiteListener {
 		String firstRunName = runs.get(0).getName();
 
 		// Send message to Slack
-		AtomicReference<String> message = new AtomicReference<>("");
+		StringBuilder message = new StringBuilder();
 		String notifyUserMessage;
 
 		if (!frameworkConfigs.getFailedCaseNotificationUserId().isEmpty()) {
@@ -288,8 +287,8 @@ public class SuiteListener implements ISuiteListener {
 			notifyUserMessage = String.format(notifyUserMessageFormat, testRailServer, notificationCount, firstRunId, firstRunName);
 		}
 
-		message.set(notifyUserMessage);
-		finalResultMap.forEach((k, v) -> message.set(message + "\n>Test Case ID: " + k + " - " + v));
-		slackbotService.sendMessageToSlackChannel(slackWebhook, message.get());
+		message.append(notifyUserMessage);
+		finalResultMap.forEach((k, v) -> message.append("\n>Test Case ID: ").append(k).append(" - ").append(v));
+		slackbotService.sendMessageToSlackChannel(slackWebhook, message.toString());
 	}
 }

--- a/src/main/java/com/scmp/framework/testng/listeners/SuiteListener.java
+++ b/src/main/java/com/scmp/framework/testng/listeners/SuiteListener.java
@@ -17,8 +17,6 @@ import org.springframework.context.ApplicationContext;
 import org.testng.ISuite;
 import org.testng.ISuiteListener;
 
-import com.slack.api.Slack;
-
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.*;

--- a/src/main/java/com/scmp/framework/testng/listeners/SuiteListener.java
+++ b/src/main/java/com/scmp/framework/testng/listeners/SuiteListener.java
@@ -50,6 +50,7 @@ public class SuiteListener implements ISuiteListener {
 
 		// Log consecutive failed test cases
 		if(!runTimeContext.isLocalExecutionMode() && frameworkConfigs.isSendFailedCaseNotification()){
+			frameworkLogger.info("Logging consecutive failed test cases...");
 			logConsecutiveFailedTestCase();
 		}
 	}
@@ -245,7 +246,7 @@ public class SuiteListener implements ISuiteListener {
 				frameworkLogger.info("Consecutive failed test cases: ");
 				finalResultMap.forEach((k,v) -> frameworkLogger.info("Test Case ID: {}, Title: {}", k, v));
 			}else{
-				frameworkLogger.info("No consecutive failed test cases found on master branch.");
+				frameworkLogger.info("No consecutive failed test cases found.");
 			}
 
 		}catch (Exception e){


### PR DESCRIPTION
Log consecutive failed test case in testrail base on following config in test project:

######################## FAILED_TESTCASE_NOTIFICATION ########################
NOTIFICATION_SEND_FAILED_CASE=true
NOTIFICATION_FAILED_CASE_TESTRUN_PATTERN.regexp=Automated Test Run \\d{1,2}/\\d{1,2}/\\d{4} master
NOTIFICATION_TESTRUN_COUNT=3
NOTIFICATION_FAILED_CASE_TESTRUN_WITHIN_DAYS=10
NOTIFICATION_FAILED_CASE_EXCLUDE_LIST=1701,1778,1779,1780,1781,1782,1783,1714,1701,1923,1797,1927,1800